### PR TITLE
Guard against null being returned.

### DIFF
--- a/src/Rx/RxLoader.php
+++ b/src/Rx/RxLoader.php
@@ -8,23 +8,26 @@ use Rx\Exception\RxException;
 final class RxLoader
 {
 
-    public static function load(string $filename): ?\stdClass
+    public static function load(string $filename): \stdClass
     {
 
         $fileContents = file_get_contents($filename);
         $fileExt = pathinfo($filename, PATHINFO_EXTENSION);
+        $typeOfFile = 'Unknown';
+        $contentsParsed = null;
 
         if (in_array($fileExt, ['yaml', 'yml']) || substr($fileContents, 0, 3) == '---') {
+            $typeOfFile = 'YAML';
             $contentsParsed = Yaml::parse($fileContents, Yaml::PARSE_OBJECT_FOR_MAP);
-        } else {
+        } else if (in_array($fileExt, ['json', 'js'])) {
+            $typeOfFile = 'JSON';
             $contentsParsed = json_decode($fileContents);
-            if (is_null($contentsParsed)) {
-                throw new RxException(sprintf('Unable to parse %s contents in \'%s\'.', in_array($fileExt, ['json', 'js']) ? 'JSON' : 'Unknown', $filename));
-            }
         }
 
+        if (is_null($contentsParsed)) {
+            throw new RxException(sprintf('Unable to parse %s contents in \'%s\'.', $typeOfFile, $filename));
+        }
         return $contentsParsed;
-
     }
 
 }


### PR DESCRIPTION
using defaults, enable the same exception as was used for JSON, to be used for YAML

move the check for JSON so that undefined types result in error case always (rather than defaulting to JSON decode with 'Unknown' as the outcome from non-js/json file extension

Fixes #1